### PR TITLE
feat(flow): Add LogSelectorNode and fix related issues

### DIFF
--- a/app/_components/Flow.tsx
+++ b/app/_components/Flow.tsx
@@ -35,6 +35,7 @@ import AfrShiftNode from "@/app/_components/FlowNodes/AfrShift/AfrShiftNode";
 import MovingAverageLogFilterNode from "@/app/_components/FlowNodes/MovingAverageLogFilter/MovingAverageLogFilterNode";
 import TableRemapNode from "@/app/_components/FlowNodes/TableRemap/TableRemapNode";
 import RomSelectorNode from "@/app/_components/FlowNodes/RomSelector/RomSelectorNode";
+import LogSelectorNode from "@/app/_components/FlowNodes/LogSelector/LogSelectorNode";
 import AfrMlShifterNode from "@/app/_components/FlowNodes/AfrMlShifter/AfrMlShifterNode";
 import TpsAfrDeleteNode from "@/app/_components/FlowNodes/TpsAfrDelete/TpsAfrDeleteNode";
 
@@ -54,7 +55,7 @@ const selector = (state: RFState) => ({
 const Flow: React.FC = () => {
   const { nodes, edges, reactFlowInstance, onNodeDragStop, setReactFlowInstance, onNodesChange, onEdgesChange, onConnect, addNode, addEdge } = useFlow(selector, shallow);
   const nodeTypes = useMemo(() => {
-    return { BaseRomNode, BaseTableNode, BaseLogNode, ForkNode, LogFilterNode, LogAlterNode, FillTableNode, FillLogTableNode, GroupNode, CombineNode, CombineAdvancedTableNode, RunningLogAlterNode, AfrShiftNode, MovingAverageLogFilterNode, TableRemapNode, romSelector: RomSelectorNode, afrMlShifter: AfrMlShifterNode, TpsAfrDeleteNode }
+    return { BaseRomNode, BaseTableNode, BaseLogNode, ForkNode, LogFilterNode, LogAlterNode, FillTableNode, FillLogTableNode, GroupNode, CombineNode, CombineAdvancedTableNode, RunningLogAlterNode, AfrShiftNode, MovingAverageLogFilterNode, TableRemapNode, romSelector: RomSelectorNode, logSelector: LogSelectorNode, afrMlShifter: AfrMlShifterNode, TpsAfrDeleteNode }
   }, [])
   const connectingNodeId = useRef<string | null>(null);
   const connectingHandleId = useRef<string | null>(null);

--- a/app/_components/FlowNodes/FlowNodesConsts.tsx
+++ b/app/_components/FlowNodes/FlowNodesConsts.tsx
@@ -14,8 +14,9 @@ import { AfrShiftData, AfrShiftType } from "@/app/_components/FlowNodes/AfrShift
 import { MovingAverageLogFilterData, MovingAverageLogFilterType } from "@/app/_components/FlowNodes/MovingAverageLogFilter/MovingAverageLogFilterTypes";
 import { AfrMlShifterData, AfrMlShifterType } from "@/app/_components/FlowNodes/AfrMlShifter/AfrMlShifterTypes";
 import { TpsAfrDeleteData, TpsAfrDeleteType } from "@/app/_components/FlowNodes/TpsAfrDelete/TpsAfrDeleteTypes";
+import { LogSelectorType } from "@/app/_components/FlowNodes/LogSelector/LogSelectorTypes";
 
-export const LogNodeTypes: string[] = [BaseLogType, LogFilterType, LogAlterType, RunningLogAlterType, MovingAverageLogFilterType, TpsAfrDeleteType]
+export const LogNodeTypes: string[] = [BaseLogType, LogFilterType, LogAlterType, RunningLogAlterType, MovingAverageLogFilterType, TpsAfrDeleteType, LogSelectorType]
 export const TableNodeTypes: string[] = [FillTableType, BaseTableType, FillLogTableType, CombineAdvancedTableType, CombineType]
 
 
@@ -34,5 +35,6 @@ export const NodeFactoryLookup = {
   [AfrShiftType]: AfrShiftData,
   [MovingAverageLogFilterType]: MovingAverageLogFilterData,
   [AfrMlShifterType]: AfrMlShifterData,
-  [TpsAfrDeleteType]: TpsAfrDeleteData
+  [TpsAfrDeleteType]: TpsAfrDeleteData,
+  [LogSelectorType]: BaseLogData
 } as const

--- a/app/_components/FlowNodes/LogSelector/LogSelectorNode.tsx
+++ b/app/_components/FlowNodes/LogSelector/LogSelectorNode.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { NodeProps, Position } from "reactflow";
+import { LogSelectorNodeType } from "./LogSelectorTypes";
+import useFlow, { RFState } from "@/app/store/useFlow";
+import { CustomHandle } from "../CustomHandle/CustomHandle";
+import useRom from "@/app/store/useRom";
+import { shallow } from "zustand/shallow";
+import { useEffect, useState } from "react";
+import { Combobox } from "@headlessui/react";
+import { BaseLogData } from "@/app/_components/FlowNodes/BaseLog/BaseLogTypes";
+import { useRomSelector } from "@/app/store/useRom";
+
+const selector = (state: RFState) => ({
+    nodes: state.nodes,
+    updateNode: state.updateNode,
+});
+
+const LogSelectorNode = ({ id, data }: NodeProps<BaseLogData>) => {
+    const { logFiles } = useRom(useRomSelector, shallow);
+    const { nodes, updateNode } = useFlow(selector, shallow);
+
+    const [query, setQuery] = useState('');
+    const [sortedLogFiles, setSortedLogFiles] = useState<FileSystemFileHandle[]>([]);
+
+    useEffect(() => {
+        const sortFiles = async () => {
+            const filesWithDates = await Promise.all(
+                logFiles.map(async (handle) => {
+                    const file = await handle.getFile();
+                    return { handle, lastModified: file.lastModified };
+                })
+            );
+
+            filesWithDates.sort((a, b) => b.lastModified - a.lastModified);
+
+            setSortedLogFiles(filesWithDates.map(item => item.handle));
+        };
+
+        sortFiles();
+    }, [logFiles]);
+
+    useEffect(() => {
+        if (sortedLogFiles.length > 0 && data.selectedLogFileNames && data.selectedLogFileNames.length > 0 && data.selectedLogFiles.length === 0) {
+            const selected = sortedLogFiles.filter(handle =>
+                data.selectedLogFileNames?.some(selectedFileName => selectedFileName === handle.name)
+            );
+            if (selected.length > 0) {
+                (async () => {
+                    const selectedLogFiles = await Promise.all(selected.map(fh => fh.getFile()));
+                    const node = nodes.find(n => n.id === id) as LogSelectorNodeType;
+                    if (!node) return;
+                    updateNode({ ...node, data: data.clone({ selectedLogFiles }) });
+                })();
+            }
+        }
+    }, [sortedLogFiles, data.selectedLogFileNames, data, id, nodes, updateNode]);
+
+    const selectedLogFileHandles = sortedLogFiles.filter(handle => 
+        data.selectedLogFileNames?.some(selectedFileName => selectedFileName === handle.name)
+    ) ?? [];
+
+    const filteredLogs = sortedLogFiles
+        .filter(file => file.name.endsWith('.csv'))
+        .filter(file => file.name.toLowerCase().includes(query.toLowerCase()));
+
+    const handleLogSelect = (fileHandles: FileSystemFileHandle[]) => {
+        (async () => {
+            const node = nodes.find(n => n.id === id) as LogSelectorNodeType;
+            if (!node) return;
+
+            const selectedLogFiles = await Promise.all(fileHandles.map(fh => fh.getFile()));
+            const selectedLogFileNames = fileHandles.map(fh => fh.name);
+            const logData = new BaseLogData({ selectedLogFiles, selectedLogFileNames });
+
+            updateNode({ ...node, data: logData });
+        })()
+    };
+
+    return (
+        <div className="nowheel node log-selector-node bg-sky-300 p-2 rounded-md w-64">
+            <div className="node-header">
+                <p className="text-black">Log Selector</p>
+            </div>
+            <div className="relative mt-2">
+                <Combobox onChange={handleLogSelect} value={selectedLogFileHandles} multiple>
+                    <Combobox.Input
+                        className="w-full rounded-md border-0 bg-sky-400 py-1.5 pl-3 pr-10 text-black focus:ring-2 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-6"
+                        onChange={(event) => setQuery(event.target.value)}
+                        displayValue={(files: FileSystemFileHandle[]) => files.length > 0 ? `${files.length} logs selected` : ''}
+                        placeholder="Select logs..."/>
+                                            <Combobox.Button className="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-none">
+                                                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l4-4 4 4m0 6l-4 4-4-4" /></svg>
+                                            </Combobox.Button>
+                    
+                                            {filteredLogs.length > 0 && (
+                                                <Combobox.Options
+                                                    className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-sky-800 py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+                                                    {filteredLogs.map((file) => (
+                                                        <Combobox.Option
+                                                            key={file.name}
+                                                            value={file}
+                                                            className={({ active }) =>
+                                                                `relative cursor-default select-none py-2 pl-10 pr-4 text-white ${active ? 'bg-sky-600' : ''}`
+                                                            }
+                                                        >
+                                                            {({ selected }) => (
+                                                                <>
+                                                                    <span className={`block break-words ${selected ? 'font-medium' : 'font-normal'}`}>
+                                                                        {file.name}
+                                                                    </span>
+                                                                    {selected ? (
+                                                                        <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-white">
+                                                                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                                                                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                                                                            </svg>
+                                                                        </span>
+                                                                    ) : null}
+                                                                </>
+                                                            )}
+                                                        </Combobox.Option>
+                                                    ))}
+                                                </Combobox.Options>
+                                            )}
+                                        </Combobox>
+                                    </div>
+                                    <CustomHandle type="source" position={Position.Right} id="log" dataType={'Log'} />
+                                </div>    );
+};
+
+export default LogSelectorNode;

--- a/app/_components/FlowNodes/LogSelector/LogSelectorNodeFactory.ts
+++ b/app/_components/FlowNodes/LogSelector/LogSelectorNodeFactory.ts
@@ -1,0 +1,10 @@
+import { nanoid } from 'nanoid';
+import { LogSelectorNodeType, LogSelectorType } from './LogSelectorTypes';
+import { BaseLogData } from '@/app/_components/FlowNodes/BaseLog/BaseLogTypes';
+
+export const LogSelectorNodeFactory = (position: { x: number; y: number; }): LogSelectorNodeType => ({
+    id: nanoid(),
+    type: LogSelectorType,
+    position,
+    data: new BaseLogData({}),
+});

--- a/app/_components/FlowNodes/LogSelector/LogSelectorTypes.tsx
+++ b/app/_components/FlowNodes/LogSelector/LogSelectorTypes.tsx
@@ -1,0 +1,6 @@
+import { NodeWithType } from "@/app/_components/FlowNodes/FlowNodesTypes";
+import { BaseLogData } from "@/app/_components/FlowNodes/BaseLog/BaseLogTypes";
+
+export const LogSelectorType = "logSelector";
+
+export type LogSelectorNodeType = NodeWithType<BaseLogData, typeof LogSelectorType>;

--- a/app/_components/NodeSelector/LogSelectorButton.tsx
+++ b/app/_components/NodeSelector/LogSelectorButton.tsx
@@ -1,0 +1,22 @@
+import useFlow, { RFState } from "@/app/store/useFlow";
+import NodeSelectorButton from "./NodeSelectorButton";
+import { LogSelectorNodeFactory } from "@/app/_components/FlowNodes/LogSelector/LogSelectorNodeFactory";
+import { shallow } from "zustand/shallow";
+
+const selector = (state: RFState) => ({
+  addNode: state.addNode,
+});
+
+export function LogSelectorButton() {
+  const { addNode } = useFlow(selector, shallow);
+
+  const handleNewNode = () => {
+    addNode(LogSelectorNodeFactory({ x: 200, y: 200 }));
+  };
+
+  return (
+    <NodeSelectorButton onClick={handleNewNode}>
+      Log Selector
+    </NodeSelectorButton>
+  );
+}

--- a/app/_components/NodeSelector/NodeSelector.tsx
+++ b/app/_components/NodeSelector/NodeSelector.tsx
@@ -20,6 +20,7 @@ import AfrMapGroup from "@/app/_components/NodeSelector/AfrMapGroup"
 import AfrShifter from "@/app/_components/NodeSelector/AfrShifter"
 import { TableRemapper } from "./TableRemapper"
 import { RomSelectorButton } from "./RomSelectorButton"
+import { LogSelectorButton } from "./LogSelectorButton";
 import { AfrMlShifterButton } from "./AfrMlShifterButton"
 import { TpsAfrDeleteData, TpsAfrDeleteNodeType, TpsAfrDeleteType } from "@/app/_components/FlowNodes/TpsAfrDelete/TpsAfrDeleteTypes"
 
@@ -80,6 +81,7 @@ const NodeSelector = () => {
       {expanded && (
         <div className="grid grid-cols-2 gap-2 mt-2">
           <div className="col-span-2">Log Filters</div>
+          <LogSelectorButton />
           <NodeSelectorButton
             onClick={() => {
               const logFilter: LogFilterNodeType = {

--- a/app/_lib/utils.ts
+++ b/app/_lib/utils.ts
@@ -30,7 +30,7 @@ export const formatter = new Intl.DateTimeFormat("en-US", {
   day: "2-digit", // '2-digit' for leading zero (e.g., 01)
   hour: "2-digit",
   minute: "2-digit",
-  hour12: false,
+  hourCycle: 'h23',
 });
 
 export const getAllFileHandles = async (

--- a/app/store/useFlow.ts
+++ b/app/store/useFlow.ts
@@ -42,6 +42,7 @@ import {
   TableRemapNodeType,
 } from "@/app/_components/FlowNodes/TableRemap/TableRemapTypes";
 import { RomSelectorNodeType } from "@/app/_components/FlowNodes/RomSelector/RomSelectorTypes";
+import { LogSelectorNodeType } from "@/app/_components/FlowNodes/LogSelector/LogSelectorTypes";
 import { AfrMlShifterNodeType } from "@/app/_components/FlowNodes/AfrMlShifter/AfrMlShifterTypes";
 import { TpsAfrDeleteNodeType } from "@/app/_components/FlowNodes/TpsAfrDelete/TpsAfrDeleteTypes";
 
@@ -74,6 +75,7 @@ export type MyNode =
   | GroupNodeType
   | TableRemapNodeType
   | RomSelectorNodeType
+  | LogSelectorNodeType
   | AfrMlShifterNodeType
   | TpsAfrDeleteNodeType;
 

--- a/app/store/useRom.ts
+++ b/app/store/useRom.ts
@@ -13,6 +13,7 @@ export type RomState = {
   romDirectoryHandle: FileSystemDirectoryHandle | null;
   romFiles: FileSystemFileHandle[];
   logDirectoryHandle: FileSystemDirectoryHandle | null;
+  logFiles: FileSystemFileHandle[];
   selectedRomMetadataHandle: FileSystemFileHandle | null;
   selectedRom: FileSystemFileHandle | null;
   scalingMap: Record<string, Scaling>;
@@ -29,7 +30,7 @@ export type RomState = {
   ) => Promise<void>;
   setLogDirectoryHandle: (
     logDirectoryHandle: FileSystemDirectoryHandle | null
-  ) => void;
+  ) => Promise<void>;
   setSelectedRomMetadataHandle: (
     selectedRomMetadataHandle: FileSystemFileHandle
   ) => void;
@@ -45,6 +46,7 @@ export function useRomSelector(state: RomState) {
     romDirectoryHandle: state.romDirectoryHandle,
     romFiles: state.romFiles,
     logDirectoryHandle: state.logDirectoryHandle,
+    logFiles: state.logFiles,
 
     selectedRomMetadataHandle: state.selectedRomMetadataHandle,
     selectedRom: state.selectedRom,
@@ -74,6 +76,7 @@ const useRom = createWithEqualityFn<RomState>()(
       romDirectoryHandle: null,
       romFiles: [],
       logDirectoryHandle: null,
+      logFiles: [],
       selectedRomMetadataHandle: null,
       selectedRom: null,
       scalingMap: {},
@@ -132,10 +135,15 @@ const useRom = createWithEqualityFn<RomState>()(
           get().setSelectedRom(rom);
         }
       },
-      setLogDirectoryHandle: (
+      setLogDirectoryHandle: async (
         logDirectoryHandle: FileSystemDirectoryHandle | null
       ) => {
-        set({ logDirectoryHandle });
+        if (logDirectoryHandle) {
+          const logFiles = await getAllFileHandles(logDirectoryHandle);
+          set({ logDirectoryHandle, logFiles });
+        } else {
+          set({ logDirectoryHandle: null, logFiles: [] });
+        }
       },
 
       setSelectedRomMetadataHandle: async (

--- a/docs/tasks/LOG_SELECTOR_NODE_IMPLEMENTATION.md
+++ b/docs/tasks/LOG_SELECTOR_NODE_IMPLEMENTATION.md
@@ -1,0 +1,58 @@
+### Introduction
+
+This document outlines the implementation of the `LogSelectorNode`. The purpose of this node is to allow users to select multiple log files from within the flow canvas. This is a significant improvement over the previous system, which relied on a single, globally selected set of logs, and enables more complex and flexible log analysis workflows.
+
+The `LogSelectorNode` will feature a searchable multi-select dropdown menu, listing all available log files from the user-selected log directory. The output of this node will be a log data object that can be connected to any node that accepts a log input, such as `LogFilterNode` or `FillLogTableNode`.
+
+---
+
+### Implementation Details
+
+#### Phase 1: State Management for Log Files
+
+-   [x] **Enhance `useRom` Store:**
+    -   The existing `useRom` store in `app/store/useRom.ts` will be updated.
+    -   A new property, `logFiles: FileSystemFileHandle[]`, will be added to the `RomState` to hold a list of all files from the selected logs directory.
+
+-   [x] **Update `setLogDirectoryHandle`:**
+    -   The `setLogDirectoryHandle` action within the `useRom` store will be updated to call the existing `getAllFileHandles` utility function.
+    -   This will populate the new `logFiles` state property, making the list of all available log files accessible to the new `LogSelectorNode`.
+
+#### Phase 2: `LogSelectorNode` Implementation
+
+-   [x] **Create Node Directory and Files:**
+    -   A new directory will be created: `app/_components/FlowNodes/LogSelector/`.
+    -   `LogSelectorTypes.tsx`: Defines the `LogSelectorNodeType` and its data structure. The data property will be an instance of `BaseLogData` to ensure compatibility with other log-processing nodes.
+    -   `LogSelectorNodeFactory.ts`: A factory to create new `LogSelectorNode` instances, initializing them with an empty `BaseLogData` object.
+    -   `LogSelectorNode.tsx`: The main component for the node.
+
+-   [x] **Implement Node UI with Headless UI:**
+    -   A searchable multi-select dropdown will be implemented. This will likely involve using the `@headlessui/react` `Combobox` component with the `multiple` prop, or a similar solution, to allow selecting multiple files.
+    -   The combobox will be populated with the list of log files from the `useRom` store.
+
+-   [x] **Implement File Sorting:**
+    -   To improve usability, the list of logs in the dropdown will be sorted by modification date, with the newest files appearing at the top.
+
+#### Phase 3: Flow Integration
+
+-   [x] **Update `useFlow.ts` Store:**
+    -   The `LogSelectorNodeType` will be added to the `MyNode` type union in `app/store/useFlow.ts`.
+
+-   [x] **Register Node in `Flow.tsx`:**
+    -   The `LogSelectorNode` component will be imported and mapped to the `logSelector` type string in the `nodeTypes` map in `app/_components/Flow.tsx`.
+
+-   [x] **Configure Node Handle:**
+    -   The `dataType` on the node's output `CustomHandle` will be set to `'Log'` to ensure it can connect correctly to other nodes in the flow.
+
+#### Phase 4: UI Integration
+
+-   [x] **Add Node to Node Selector UI:**
+    -   A new button component will be created to add the `LogSelectorNode` to the canvas.
+    -   This button will be added to the main `app/_components/NodeSelector/NodeSelector.tsx` component, making it accessible in the UI.
+
+#### Phase 5: Testing
+
+-   [ ] **Perform Integration Testing (Manual):**
+    -   The node will be tested by adding it to the flow and selecting one or more log files.
+    -   Connection to a `LogFilterNode` and other relevant nodes will be verified to work correctly.
+    -   The data flow and processing will be checked to ensure the selected logs are correctly passed to downstream nodes.


### PR DESCRIPTION
This commit introduces the `LogSelectorNode`, which allows users to select multiple log files directly within the flow canvas. This enhances the flexibility of log analysis by moving away from a single global log selection.

Key features and fixes include:
- A new `LogSelectorNode` with a searchable multi-select dropdown for log files.
- Sorting of log files by modification date.
- Fixes for several issues encountered during implementation, including:
  - Text wrapping for long file names in the dropdown.
  - Correctly cloning `logSelector` nodes when saving groups.
  - Persisting selected logs when saving.
  - A `QuotaExceededError` caused by storing logs in local storage.
  - A build error resolved by clearing the Next.js cache.
  - A TypeScript error in the `Combobox` component.
- Addressed linting warnings.